### PR TITLE
fix(ProfileProvider): Unset profileData if no account is connected

### DIFF
--- a/src/app/components/providers/profileProvider.tsx
+++ b/src/app/components/providers/profileProvider.tsx
@@ -46,6 +46,7 @@ export function ProfileProvider({ children }: { children: ReactNode }) {
     async function fetchProfile() {
       if (!walletConnected || !accounts[0]) {
         console.log('Skipping profile fetch - not connected or no accounts:', { walletConnected, accounts });
+        setProfileData(null);
         return;
       }
 


### PR DESCRIPTION
Unset `profileData` when no account is connected.